### PR TITLE
Fix NUMA detection issue with SIOV

### DIFF
--- a/sources/core-iaa/sources/accelerator/enqueue.cpp
+++ b/sources/core-iaa/sources/accelerator/enqueue.cpp
@@ -36,7 +36,13 @@ extern "C" hw_accelerator_status hw_enqueue_descriptor(void *desc_ptr, int32_t d
         const auto &device = dispatcher.device(device_idx);
         device_idx = (device_idx+1) % device_count;
 
-        if (device.numa_id() != (uint64_t)numa_id) {
+        /*
+         * The device NUMA ID is -1 when the device is used in the VM and the
+         * VM does not explicity configure NUMA information.
+         * In this case, the CPUs in the VM should be physically the same NUMA
+         * node as this device, then use this device directly.
+         */
+        if (((device.numa_id() != (uint64_t)numa_id)) && (device.numa_id() != (uint64_t)(-1))) {
             continue;
         }
 


### PR DESCRIPTION
The QPL uses IAA hardware device according to system NUMA configuration,if
the device is used in the VM (Virtual Machine) and the VM has no NUMA
configuration, the device NUMA ID is -1 that leads the device not to
work.

So if the device NUMA ID is -1, QPL no longer check the NUMA information
of the device and uses this device directly.

Signed-off-by: yliu80 <yuan1.liu@intel.com>