### PR TITLE
QPL provide release package can be built directly by using cmake flag 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(LOG_HW_INIT "Enables HW initialization log" OFF)
 option(EFFICIENT_WAIT "Enables usage of efficient wait instructions" OFF)
 option(LIB_FUZZING_ENGINE "Enables fuzzy testing" OFF)
 option(DWQ_SUPPORT "Enables Dedicated Work Queue" OFF)
+option(ENABLE_TESTS "Enables testing" ON)
 
 if (SANITIZE_MEMORY)
     message(STATUS "Memory sanitizing build is enabled")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,8 +14,10 @@ if (LIB_FUZZING_ENGINE)
 else ()
     add_subdirectory(ref)
     add_subdirectory(utils)
-    add_subdirectory(third-party/google-test EXCLUDE_FROM_ALL)
-    add_subdirectory(tests)
+    if (ENABLE_TESTS)
+        add_subdirectory(third-party/google-test EXCLUDE_FROM_ALL)
+        add_subdirectory(tests)
+    endif()
 endif ()
 
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/configs


### PR DESCRIPTION

[issue#9](https://github.com/intel/qpl/issues/9)
 QPL cannot provide a release package that can be built from direct downloadable files (.tar, .tgz) since the current release packages has no google-test submodules.
This PR is trying to solve this issue.