### PR TITLE
[build] Install configs and scripts inside /share/QPL directory

### DIFF
--- a/doc/source/documentation/get_started_docs/installation.rst
+++ b/doc/source/documentation/get_started_docs/installation.rst
@@ -60,9 +60,9 @@ via the Intel® QPL source or from the Intel® QPL installed directory:
 
 .. code-block:: shell
 
-   sudo python3 <install-dir>/bin/scripts/accel_conf.py <config file> --load=<path to config file>
+   sudo python3 <install-dir>/share/QPL/scripts/accel_conf.py <config file> --load=<path to config file>
 
-With configuration files found at either ``<qpl-library>/tools/configs/`` or ``<install-dir>/bin/configs/``.
+With configuration files found at either ``<qpl-library>/tools/configs/`` or ``<install-dir>/share/QPL/configs/``.
 With configuration files of the format ``<# nodes>n<# devices>d<# engines>e<# of workqueues>w-s.conf`` or
 ``<# nodes>n<# devices>d<# engines>e<# of workqueues>w-s-n<which node>.conf``.
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -28,9 +28,9 @@ if (QPL_BUILD_TESTS)
 endif ()
 
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/configs
-                  TYPE             BIN
+                  DESTINATION share/${CMAKE_PROJECT_NAME}
                   COMPONENT        RUNTIME)
 install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/scripts
-                  TYPE             BIN
+                  DESTINATION share/${CMAKE_PROJECT_NAME}
                   COMPONENT        RUNTIME
                   FILE_PERMISSIONS USE_SOURCE_PERMISSIONS)


### PR DESCRIPTION
To be compliance with the Linux file system hierarchy [1], move the configs and scripts installation path to be inside <install-dir>/share/QPL directory.

This helps to be integrated/packaged to any Linux distro.

[1]  https://www.freedesktop.org/software/systemd/man/file-hierarchy.html