### PR TITLE
[fix] fix dispatch table copy

### DIFF
--- a/sources/middle-layer/analytics/expand.cpp
+++ b/sources/middle-layer/analytics/expand.cpp
@@ -22,7 +22,7 @@ static inline auto expand(input_stream_t &input_stream,
                           output_stream_t<array_stream> &output_stream,
                           core_sw::dispatcher::aggregates_function_ptr_t aggregates_callback,
                           aggregates_t &aggregates) noexcept -> uint32_t {
-    const auto table       = core_sw::dispatcher::kernels_dispatcher::get_instance().get_expand_table();
+    const auto &table       = core_sw::dispatcher::kernels_dispatcher::get_instance().get_expand_table();
     const auto index       = core_sw::dispatcher::get_expand_index(input_stream.bit_width());
     const auto expand_impl = table[index];
 
@@ -115,7 +115,7 @@ auto call_expand<execution_path_t::software>(input_stream_t &input_stream,
                                              limited_buffer_t &output_buffer,
                                              int32_t UNREFERENCED_PARAMETER(numa_id)) noexcept -> analytic_operation_result_t {
     // Get required aggregates kernel
-    auto aggregates_table    = core_sw::dispatcher::kernels_dispatcher::get_instance().get_aggregates_table();
+    auto &aggregates_table   = core_sw::dispatcher::kernels_dispatcher::get_instance().get_aggregates_table();
     auto aggregates_index    = core_sw::dispatcher::get_aggregates_index(1u);
     auto aggregates_callback = (input_stream.are_aggregates_disabled()) ?
                                 &aggregates_empty_callback :

--- a/sources/middle-layer/analytics/extract.cpp
+++ b/sources/middle-layer/analytics/extract.cpp
@@ -21,7 +21,7 @@ static inline auto extract(input_stream_t &input_stream,
                            aggregates_t &aggregates,
                            const uint32_t param_low,
                            const uint32_t param_high) noexcept -> uint32_t {
-    auto     table        = core_sw::dispatcher::kernels_dispatcher::get_instance().get_extract_i_table();
+    auto     &table       = core_sw::dispatcher::kernels_dispatcher::get_instance().get_extract_i_table();
     uint32_t index        = core_sw::dispatcher::get_extract_index(input_stream.bit_width());
     auto     extract_impl = table[index];
 
@@ -155,7 +155,7 @@ auto call_extract<execution_path_t::software>(input_stream_t &input_stream,
     uint32_t                    input_bit_width = input_stream.bit_width();
     uint32_t                    status_code     = status_list::ok;
 
-    auto aggregates_table    = core_sw::dispatcher::kernels_dispatcher::get_instance().get_aggregates_table();
+    auto &aggregates_table    = core_sw::dispatcher::kernels_dispatcher::get_instance().get_aggregates_table();
     auto aggregates_index    = core_sw::dispatcher::get_aggregates_index(input_bit_width);
     auto aggregates_callback = (input_stream.are_aggregates_disabled()) ?
                                       &aggregates_empty_callback :
@@ -164,7 +164,7 @@ auto call_extract<execution_path_t::software>(input_stream_t &input_stream,
     if ((input_bit_width == 8u || input_bit_width == 16u || input_bit_width == 32u) &&
         input_stream.stream_format() == stream_format_t::le_format &&
         !input_stream.is_compressed()) {
-        auto     extract_table  = core_sw::dispatcher::kernels_dispatcher::get_instance().get_extract_table();
+        auto     &extract_table  = core_sw::dispatcher::kernels_dispatcher::get_instance().get_extract_table();
         uint32_t extract_index  = core_sw::dispatcher::get_extract_index(input_bit_width);
         auto     extract_kernel = extract_table[extract_index];
 

--- a/sources/middle-layer/analytics/input_stream.cpp
+++ b/sources/middle-layer/analytics/input_stream.cpp
@@ -189,8 +189,8 @@ auto input_stream_t::unpack<analytic_pipeline::inflate_prle>(limited_buffer_t &o
 }
 
 auto input_stream_t::initialize_sw_kernels() noexcept -> void {
-    auto unpack_table      = core_sw::dispatcher::kernels_dispatcher::get_instance().get_unpack_table();
-    auto unpack_prle_table = core_sw::dispatcher::kernels_dispatcher::get_instance().get_unpack_prle_table();
+    auto &unpack_table      = core_sw::dispatcher::kernels_dispatcher::get_instance().get_unpack_table();
+    auto &unpack_prle_table = core_sw::dispatcher::kernels_dispatcher::get_instance().get_unpack_prle_table();
 
     uint32_t is_stream_be = (stream_format_ == stream_format_t::be_format) ? 1 : 0;
 

--- a/sources/middle-layer/analytics/output_stream.hpp
+++ b/sources/middle-layer/analytics/output_stream.hpp
@@ -157,7 +157,7 @@ public:
         stream_.destination_current_ptr_ = stream_.data();
 
         if constexpr(path == execution_path_t::software || path == execution_path_t::auto_detect) {
-            auto pack_table = core_sw::dispatcher::kernels_dispatcher::get_instance().get_pack_index_table();
+            auto &pack_table = core_sw::dispatcher::kernels_dispatcher::get_instance().get_pack_index_table();
             stream_.capacity_ = (std::distance(stream_.begin(), stream_.end()) * byte_bits_size)
                                 / stream_.actual_bit_width_;
 

--- a/sources/middle-layer/analytics/scan.hpp
+++ b/sources/middle-layer/analytics/scan.hpp
@@ -47,7 +47,7 @@ static inline auto scan(input_stream_t &input_stream,
                         aggregates_t &aggregates,
                         uint32_t param_low,
                         uint32_t param_high) noexcept -> uint32_t {
-    auto table     = core_sw::dispatcher::kernels_dispatcher::get_instance().get_scan_i_table();
+    auto &table     = core_sw::dispatcher::kernels_dispatcher::get_instance().get_scan_i_table();
     auto index     = core_sw::dispatcher::get_scan_index(input_stream.bit_width(), static_cast<uint32_t>(comparator));
     auto scan_impl = table[index];
 
@@ -145,7 +145,7 @@ static inline auto call_scan_sw(input_stream_t &input_stream,
     auto corrected_param_low  = correct_input_param(input_bit_width, param_low);
     auto corrected_param_high = correct_input_param(input_bit_width, param_high);
 
-    auto aggregates_table    = core_sw::dispatcher::kernels_dispatcher::get_instance().get_aggregates_table();
+    auto &aggregates_table    = core_sw::dispatcher::kernels_dispatcher::get_instance().get_aggregates_table();
     auto aggregates_index    = core_sw::dispatcher::get_aggregates_index(1u);
     auto aggregates_callback = (input_stream.are_aggregates_disabled()) ?
                                 &aggregates_empty_callback :
@@ -155,7 +155,7 @@ static inline auto call_scan_sw(input_stream_t &input_stream,
         input_stream.stream_format() == stream_format_t::le_format &&
         !input_stream.is_compressed()) {
 
-        auto scan_table  = core_sw::dispatcher::kernels_dispatcher::get_instance().get_scan_table();
+        auto &scan_table  = core_sw::dispatcher::kernels_dispatcher::get_instance().get_scan_table();
         auto scan_index  = core_sw::dispatcher::get_scan_index(input_bit_width, (uint32_t) comparator);
         auto scan_kernel = scan_table[scan_index];
 

--- a/sources/middle-layer/analytics/select.cpp
+++ b/sources/middle-layer/analytics/select.cpp
@@ -22,7 +22,7 @@ static inline auto select(input_stream_t &input_stream,
                           limited_buffer_t &output_buffer,
                           core_sw::dispatcher::aggregates_function_ptr_t aggregates_callback,
                           aggregates_t &aggregates) noexcept -> uint32_t {
-    auto        table       = core_sw::dispatcher::kernels_dispatcher::get_instance().get_select_table();
+    auto        &table      = core_sw::dispatcher::kernels_dispatcher::get_instance().get_select_table();
     const auto  index       = core_sw::dispatcher::get_select_index(input_stream.bit_width());
     const auto  select_impl = table[index];
 
@@ -98,7 +98,7 @@ auto call_select<execution_path_t::software>(input_stream_t &input_stream,
                                              limited_buffer_t &output_buffer,
                                              int32_t UNREFERENCED_PARAMETER(numa_id)) noexcept -> analytic_operation_result_t {
     // Get required aggregates kernel
-    auto aggregates_table    = core_sw::dispatcher::kernels_dispatcher::get_instance().get_aggregates_table();
+    auto &aggregates_table    = core_sw::dispatcher::kernels_dispatcher::get_instance().get_aggregates_table();
     auto aggregates_index    = core_sw::dispatcher::get_aggregates_index(1u);
     auto aggregates_callback = (input_stream.are_aggregates_disabled()) ?
                                 &aggregates_empty_callback :

--- a/sources/middle-layer/compression/huffman_table/huffman_table_utils.cpp
+++ b/sources/middle-layer/compression/huffman_table/huffman_table_utils.cpp
@@ -186,7 +186,7 @@ static inline void store_isal_deflate_header(isal_hufftables *isal_huffman_table
     header_complete_byte_size += (0u == isal_huffman_table->deflate_hdr_extra_bits) ? 0u : 1u;
 
     // Use copy kernel to copy deflate header from isal huffman tables
-    auto copy_kernel = core_sw::dispatcher::kernels_dispatcher::get_instance().get_memory_copy_table();
+    auto &copy_kernel = core_sw::dispatcher::kernels_dispatcher::get_instance().get_memory_copy_table();
     copy_kernel[0]((uint8_t *) isal_huffman_table->deflate_hdr,
                    compression_table.get_deflate_header_data(),
                    header_complete_byte_size);
@@ -1279,4 +1279,3 @@ bool is_equal(qpl_decompression_huffman_table &table,
 }
 
 };
-

--- a/tools/tests/functional/unit_tests/algorithmic/core_mem_move.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_mem_move.cpp
@@ -22,7 +22,7 @@ constexpr uint32_t TEST_SOURCE_SIZE = TEST_ARRAY_SIZE / 2u;
 constexpr uint32_t TEST_SPAN_SIZE   = TEST_ARRAY_SIZE / 4u;
 
 static inline qplc_move_t_ptr move() {
-    static const auto& table = qpl::core_sw::dispatcher::kernels_dispatcher::get_instance().get_move_table();
+    static const auto &table = qpl::core_sw::dispatcher::kernels_dispatcher::get_instance().get_move_table();
 
     return (qplc_move_t_ptr)table[0u];
 }

--- a/tools/tests/functional/unit_tests/algorithmic/core_zero_8u.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_zero_8u.cpp
@@ -17,7 +17,7 @@
 namespace qpl::test {
 
     qplc_zero_t_ptr qplc_zero() {
-        static const auto& table = qpl::core_sw::dispatcher::kernels_dispatcher::get_instance().get_zero_table();
+        static const auto &table = qpl::core_sw::dispatcher::kernels_dispatcher::get_instance().get_zero_table();
 
         return (qplc_zero_t_ptr)table[0u];
     }


### PR DESCRIPTION
Hi,

while comparing QPL to [TUM Umbra's](https://umbra-db.com/) related functionality, I noticed that the former has a large overhead for small amounts of tuples. After investigating with VTune and the following microbenchmark, I think I found a typo that leads to an accidental copy of the function pointer table in `input_stream_t::initialize_sw_kernels`. Here's the benchmark:

```cpp
#include "qpl/qpl.h"
#include <benchmark/benchmark.h>

#include "../DataDistribution.hpp"
#include "../Utils.hpp"

int main() {
    // pointer wrapper with destructor
   ExecutionContext fixture(qpl_path_software);
   qpl_job* job = reinterpret_cast<qpl_job*>(fixture.getExecutionContext());

   uint32_t numTuples = 1;
   double selectivity = 0.5;
   uint32_t inBitWidth = 8;
   qpl_out_format outFormat = qpl_out_format::qpl_ow_32;

   // private utilities, does what you would expect
   LittleEndianBufferBuilder builder(inBitWidth, numTuples);
   Dataset dataset = UniformDistribution::generateDataset(
      builder,
      inBitWidth,
      (1ul << inBitWidth) - 1,
      numTuples,
      umbra::VectorizedFunctions::Mode::Eq,
      selectivity);
   std::vector<uint8_t> destination;
   destination.resize(divceil(32 * numTuples, 8));

   for (size_t i = 0; i < 1'000'000'000; i++) {
      if (i % 1'000'000 == 0) {
         std::cout << i << std::endl;
      }

      // Parameterize jobs.
      {
         job->parser = builder.getQPLParser();
         job->next_in_ptr = dataset.data.data();
         job->available_in = dataset.data.size();
         job->next_out_ptr = destination.data();
         job->available_out = static_cast<uint32_t>(destination.size());
         job->op = map_umbra_to_qpl_op(umbra::VectorizedFunctions::Mode::Eq);
         job->src1_bit_width = inBitWidth;
         job->num_input_elements = numTuples;
         job->out_bit_width = outFormat;
         auto [param_low, param_high] = dataset.predicateArguments->template getValues<uint32_t, 2>();
         job->param_low = param_low;
         job->param_high = param_high;
         job->flags = static_cast<uint32_t>(QPL_FLAG_OMIT_CHECKSUMS | QPL_FLAG_OMIT_AGGREGATES);
      }

      qpl_status status = qpl_execute_job(job);
      if (status != QPL_STS_OK) {
         ERROR("An error occurred during job execution: " << status);
      }

      const auto indicesByteSize = job->total_out;
      const auto bytesPerHit = divceil(32, 8);
      const auto qplHits = indicesByteSize / bytesPerHit;
      if ((outFormat != qpl_ow_nom && qplHits != dataset.predicateHits)) {
         ERROR("Result does not fit expectations: " << qplHits << " != " << dataset.predicateHits);
      } else if (outFormat == qpl_ow_nom && job->total_out != divceil(numTuples, 8)) {
         ERROR("Result does not fit expectations: " << job->total_out << " != " << divceil(numTuples, 8));
      }

      benchmark::DoNotOptimize(job->total_out);
      benchmark::DoNotOptimize(status);
      benchmark::DoNotOptimize(destination);
      benchmark::ClobberMemory();
   }
}
```

The benchmark was run for 15s on an i9 13900K. Screenshot of VTune summary before the PR:

![Screenshot 2023-09-03 at 12 45 58](https://github.com/intel/qpl/assets/14094195/d89d254c-e5ca-42ba-98de-058c49e98c7f)

after the PR:

![Screenshot 2023-09-03 at 13 39 15](https://github.com/intel/qpl/assets/14094195/c2444980-e1ec-4173-aa27-054efb246ea8)