### PR TITLE
Fixing a small bug in compression_multi_chunk_example.cpp

### DIFF
--- a/examples/low-level-api/compression_multi_chunk_example.cpp
+++ b/examples/low-level-api/compression_multi_chunk_example.cpp
@@ -85,13 +85,14 @@ auto main(int argc, char** argv) -> int {
 
     // QPL_FLAG_LAST is set in the last chunk
     while (source_bytes_left > 0) {
+        int previous_chunk_size = chunk_size;
         if (chunk_size >= source_bytes_left) {
             job->flags |= QPL_FLAG_LAST;
             chunk_size = source_bytes_left;
         }
 
         source_bytes_left -= chunk_size;
-        job->next_in_ptr  = source.data() + iteration_count * chunk_size;
+        job->next_in_ptr  = source.data() + iteration_count * previous_chunk_size;
         job->available_in = chunk_size;
 
         // Execute compression operation


### PR DESCRIPTION
# Description

There is a small bug [here](https://github.com/intel/qpl/blob/14d9417949309f17cb4f83e2325a79047f70a926/examples/low-level-api/compression_multi_chunk_example.cpp#L94). If source.size() % chunk_count != 0, chunk_size will be the reminder at the last iteration, and it will produce a wrong offset in the source pointer.

The issue can be reproduced when compressing more dispersed data than the given `source` vector.

# Checklist

N/A since it's a small bug in the examples.