### PR TITLE
Permanence AI header fixes

### DIFF
--- a/sources/core-sw/src/compression/opt/placeholder.h
+++ b/sources/core-sw/src/compression/opt/placeholder.h
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef PLACEHOLDER_H
+#define PLACEHOLDER_H
+
 /*
  *  Intel® Query Processing Library (Intel® QPL)
  *  SW Core API (Private API)
  */
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_16u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_16u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_16U_K0_H
+#define QPLC_UNPACK_16U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit data to words
  * @date 08/02/2020
@@ -541,3 +544,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_15u16u, (const uint8_t *src_ptr,
         px_qplc_unpack_Nu16u(src_ptr, num_elements, 0u, 15u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_8u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_8u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_8U_K0_H
+#define QPLC_UNPACK_8U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit data to bytes
  * @date 08/02/2020
@@ -1010,3 +1013,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_7u8u, (const uint8_t *src_ptr,
         px_qplc_unpack_7u8u(src_ptr, num_elements, 0u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_16u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_16u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_BE_16U_K0_H
+#define QPLC_UNPACK_BE_16U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit BE data to words
  * @date 07/06/2020
@@ -914,3 +917,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_16u16u, (const uint8_t *src_ptr,
         dst16u_ptr[i] = qplc_swap_bytes_16u(src16u_ptr[i]);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_32u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_32u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_BE_32U_K0_H
+#define QPLC_UNPACK_BE_32U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 17..32-bit BE data to dwords
  * @date 07/06/2020
@@ -1911,3 +1914,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_32u32u, (const uint8_t *src_ptr,
         dst32u_ptr[i] = qplc_swap_bytes_32u(src32u_ptr[i]);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_8u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_8u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_BE_8U_K0_H
+#define QPLC_UNPACK_BE_8U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit BE data to bytes
  * @date 07/06/2020
@@ -547,3 +550,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_7u8u, (const uint8_t *src_ptr,
         px_qplc_unpack_be_Nu8u(src_ptr, num_elements, 0u, 7u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/isal/igzip/huffman.h
+++ b/sources/isal/igzip/huffman.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef HUFFMAN_H
+#define HUFFMAN_H
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -359,3 +362,5 @@ static inline int compare(uint8_t * str1, uint8_t * str2, uint32_t max_length)
 
     return count;
 }
+
+#endif

--- a/sources/isal/igzip/igzip_wrapper.h
+++ b/sources/isal/igzip/igzip_wrapper.h
@@ -5,6 +5,8 @@
  ******************************************************************************/
 
 #ifndef IGZIP_WRAPPER_H
+#define IGZIP_WRAPPER_H
+
 
 #define DEFLATE_METHOD 8
 #define ZLIB_DICT_FLAG (1 << 5)

--- a/sources/isal/igzip/static_inflate.h
+++ b/sources/isal/igzip/static_inflate.h
@@ -1349,7 +1349,6 @@ struct inflate_huff_code_small static_dist_huff_code = {
         0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000	}
 };
 
-#endif
 struct inflate_huff_code_large pregen_lit_huff_code = {
     .short_code_lookup = {
         0x24000102, 0x88010265, 0x44000103, 0xa8010277,
@@ -2682,3 +2681,4 @@ struct inflate_huff_code_small pregen_dist_huff_code = {
         0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000	}
 };
 
+#endif


### PR DESCRIPTION
# Description

This PR covers several fixes to header files which are missing include guards, or have include guards which are incorrect. In addition, it adds header files for .c source files which are missing header files.

All code updates were made by the Permanence AI Coder bot.

# Checklist

## All Submissions

- [ ] Attached log with the results of functional testing using `software_path` and/or `hardware_path`. Required testing coverage depends on the nature of changes, e.g., changes to the API or middle-layer imply testing of both, however changes focused on `core-iaa/` only require `hardware_path`. If testing is not possible on the contributor side (e.g., due to lack of resources), please let maintainers know. More information on testing is in [Documentation](https://intel.github.io/qpl/documentation/get_started_docs/testing.html).

## New Features

- [ ] Added copyrights for all new files.
- [ ] Added doxygen comments for all new APIs.
- [ ] Added relevant tests.
- [ ] Added relevant examples and documentation (if required).

## Bug Fixes

- [ ] Added relevant regression tests.
- [ ] Included information on how to reproduce the issue (either in a
      GitHub issue or in this PR).