### PR TITLE
add missing or correct errors in header guards for 9 files

### DIFF
--- a/sources/core-sw/src/compression/opt/placeholder.h
+++ b/sources/core-sw/src/compression/opt/placeholder.h
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_COMPRESSION_OPT_PLACEHOLDER_H
+#define QPL_SOURCES_CORE_SW_SRC_COMPRESSION_OPT_PLACEHOLDER_H
+
 /*
  *  Intel® Query Processing Library (Intel® QPL)
  *  SW Core API (Private API)
  */
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_16u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_16u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_16U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_16U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit data to words
  * @date 08/02/2020
@@ -541,3 +544,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_15u16u, (const uint8_t *src_ptr,
         px_qplc_unpack_Nu16u(src_ptr, num_elements, 0u, 15u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_8u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_8u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_8U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_8U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit data to bytes
  * @date 08/02/2020
@@ -1010,3 +1013,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_7u8u, (const uint8_t *src_ptr,
         px_qplc_unpack_7u8u(src_ptr, num_elements, 0u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_16u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_16u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_16U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_16U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit BE data to words
  * @date 07/06/2020
@@ -914,3 +917,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_16u16u, (const uint8_t *src_ptr,
         dst16u_ptr[i] = qplc_swap_bytes_16u(src16u_ptr[i]);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_32u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_32u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_32U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_32U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 17..32-bit BE data to dwords
  * @date 07/06/2020
@@ -1911,3 +1914,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_32u32u, (const uint8_t *src_ptr,
         dst32u_ptr[i] = qplc_swap_bytes_32u(src32u_ptr[i]);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_8u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_8u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_8U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_8U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit BE data to bytes
  * @date 07/06/2020
@@ -547,3 +550,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_7u8u, (const uint8_t *src_ptr,
         px_qplc_unpack_be_Nu8u(src_ptr, num_elements, 0u, 7u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/isal/igzip/huffman.h
+++ b/sources/isal/igzip/huffman.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_ISAL_IGZIP_HUFFMAN_H
+#define QPL_SOURCES_ISAL_IGZIP_HUFFMAN_H
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -359,3 +362,5 @@ static inline int compare(uint8_t * str1, uint8_t * str2, uint32_t max_length)
 
     return count;
 }
+
+#endif

--- a/sources/isal/igzip/igzip_wrapper.h
+++ b/sources/isal/igzip/igzip_wrapper.h
@@ -5,6 +5,8 @@
  ******************************************************************************/
 
 #ifndef IGZIP_WRAPPER_H
+#define IGZIP_WRAPPER_H
+
 
 #define DEFLATE_METHOD 8
 #define ZLIB_DICT_FLAG (1 << 5)

--- a/sources/isal/igzip/static_inflate.h
+++ b/sources/isal/igzip/static_inflate.h
@@ -1349,7 +1349,6 @@ struct inflate_huff_code_small static_dist_huff_code = {
         0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000	}
 };
 
-#endif
 struct inflate_huff_code_large pregen_lit_huff_code = {
     .short_code_lookup = {
         0x24000102, 0x88010265, 0x44000103, 0xa8010277,
@@ -2682,3 +2681,4 @@ struct inflate_huff_code_small pregen_dist_huff_code = {
         0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000	}
 };
 
+#endif


### PR DESCRIPTION
# Description

The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by myself. This bugfix PR updates several header files to add include guards which were previously missing and two files to fix include guards which were incorrect.

        - modify sources/core-sw/src/compression/opt/placeholder.h (add missing include guard)
        - modify sources/core-sw/src/filtering/opt/qplc_unpack_16u_k0.h (add missing include guard)
        - modify sources/core-sw/src/filtering/opt/qplc_unpack_8u_k0.h (add missing include guard)
        - modify sources/core-sw/src/filtering/opt/qplc_unpack_be_16u_k0.h (add missing include guard)
        - modify sources/core-sw/src/filtering/opt/qplc_unpack_be_32u_k0.h (add missing include guard)
        - modify sources/core-sw/src/filtering/opt/qplc_unpack_be_8u_k0.h (add missing include guard)
        - modify sources/isal/igzip/huffman.h (add missing include guard)
        - modify sources/isal/igzip/igzip_wrapper.h (add missing #define inside include guard)
        - modify sources/isal/igzip/static_inflate.h (incorrectly located #endif of include guard)

on-behalf-of: @permanence-ai github-ai@permanence.ai

# Checklist

- No new tests as this is purely a build-time correctness update
- Software path test results had only expected failures (per latest release notes) following the changes:

```
[----------] Global test environment tear-down
[==========] 385 tests from 125 test suites ran. (441480 ms total)
[  PASSED  ] 334 tests.
[  SKIPPED ] 45 tests, listed below:
. . .
[  FAILED  ] 6 tests, listed below:
[  FAILED  ] ta_c_api_deflate_stateful.dynamic_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.dynamic_high_verify
[  FAILED  ] ta_c_api_deflate_stateful.fixed_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.fixed_high_verify
[  FAILED  ] ta_c_api_deflate_stateful.static_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.static_high_verify
```