### PR TITLE
correct header guards and add missing headers and declarations

### DIFF
--- a/sources/core-sw/src/compression/include/deflate_slow_matcher.h
+++ b/sources/core-sw/src/compression/include/deflate_slow_matcher.h
@@ -24,4 +24,11 @@ deflate_match_t get_lazy_best_match(const deflate_hash_table_t *const hash_table
 }
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+    deflate_match_t get_lazy_best_match(const deflate_hash_table_t * const hash_table_ptr, const uint8_t * const lower_bound_ptr, const uint8_t * const string_ptr, const uint8_t * const upper_bound_ptr);
+#ifdef __cplusplus
+} // extern "C"
+#endif
 #endif // QPLC_DEFLATE_SLOW_MATCHER_H_

--- a/sources/core-sw/src/compression/opt/placeholder.h
+++ b/sources/core-sw/src/compression/opt/placeholder.h
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_COMPRESSION_OPT_PLACEHOLDER_H
+#define QPL_SOURCES_CORE_SW_SRC_COMPRESSION_OPT_PLACEHOLDER_H
+
 /*
  *  Intel® Query Processing Library (Intel® QPL)
  *  SW Core API (Private API)
  */
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_16u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_16u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_16U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_16U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit data to words
  * @date 08/02/2020
@@ -541,3 +544,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_15u16u, (const uint8_t *src_ptr,
         px_qplc_unpack_Nu16u(src_ptr, num_elements, 0u, 15u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_8u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_8u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_8U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_8U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit data to bytes
  * @date 08/02/2020
@@ -1010,3 +1013,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_7u8u, (const uint8_t *src_ptr,
         px_qplc_unpack_7u8u(src_ptr, num_elements, 0u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_16u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_16u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_16U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_16U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit BE data to words
  * @date 07/06/2020
@@ -914,3 +917,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_16u16u, (const uint8_t *src_ptr,
         dst16u_ptr[i] = qplc_swap_bytes_16u(src16u_ptr[i]);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_32u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_32u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_32U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_32U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 17..32-bit BE data to dwords
  * @date 07/06/2020
@@ -1911,3 +1914,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_32u32u, (const uint8_t *src_ptr,
         dst32u_ptr[i] = qplc_swap_bytes_32u(src32u_ptr[i]);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_8u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_8u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_8U_K0_H
+#define QPL_SOURCES_CORE_SW_SRC_FILTERING_OPT_QPLC_UNPACK_BE_8U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit BE data to bytes
  * @date 07/06/2020
@@ -547,3 +550,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_7u8u, (const uint8_t *src_ptr,
         px_qplc_unpack_be_Nu8u(src_ptr, num_elements, 0u, 7u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/isal/igzip/adler32_base.c
+++ b/sources/isal/igzip/adler32_base.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
+
+#include "adler32_base.h"
 #include <stddef.h>
 #include <stdint.h>
 #include "igzip_checksums.h"

--- a/sources/isal/igzip/adler32_base.h
+++ b/sources/isal/igzip/adler32_base.h
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPL_SOURCES_ISAL_IGZIP_ADLER32_BASE_C
+#define QPL_SOURCES_ISAL_IGZIP_ADLER32_BASE_C
+
+// includes extracted from sources/isal/igzip/adler32_base.c
+#include <stddef.h>
+#include <stdint.h>
+#include "igzip_checksums.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    uint32_t qpl_adler32_base(uint32_t adler32, uint8_t *start, uint32_t length);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+
+#endif

--- a/sources/isal/igzip/encode_df.h
+++ b/sources/isal/igzip/encode_df.h
@@ -41,3 +41,10 @@ struct deflate_icf *qpl_encode_deflate_icf(struct deflate_icf *next_in, struct d
 }
 #endif
 #endif
+#ifdef __cplusplus
+extern "C" {
+#endif
+    struct deflate_icf *qpl_encode_deflate_icf_base(struct deflate_icf *next_in, struct deflate_icf *end_in, struct BitBuf2 *bb, struct hufftables_icf *hufftables);
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/sources/isal/igzip/huff_codes.h
+++ b/sources/isal/igzip/huff_codes.h
@@ -156,4 +156,11 @@ qpl_create_hufftables_icf(struct BitBuf2 *bb, struct hufftables_icf * hufftables
 #endif
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void qpl_isal_update_histogram_base(uint8_t *start_stream, int length, struct isal_huff_histogram *histogram);
+#ifdef __cplusplus
+} // extern "C"
+#endif
 #endif

--- a/sources/isal/igzip/huffman.h
+++ b/sources/isal/igzip/huffman.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPL_SOURCES_ISAL_IGZIP_HUFFMAN_H
+#define QPL_SOURCES_ISAL_IGZIP_HUFFMAN_H
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -359,3 +362,5 @@ static inline int compare(uint8_t * str1, uint8_t * str2, uint32_t max_length)
 
     return count;
 }
+
+#endif

--- a/sources/isal/igzip/igzip.c
+++ b/sources/isal/igzip/igzip.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip.h"
+
 #define ASM
 
 #include <assert.h>

--- a/sources/isal/igzip/igzip.h
+++ b/sources/isal/igzip/igzip.h
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPL_SOURCES_ISAL_IGZIP_IGZIP_C
+#define QPL_SOURCES_ISAL_IGZIP_IGZIP_C
+
+// includes extracted from sources/isal/igzip/igzip.c
+#include <assert.h>
+#include <string.h>
+#ifdef _WIN32
+# include <intrin.h>
+#endif
+#include "huffman.h"
+#include "bitbuf2.h"
+#include "igzip_lib.h"
+#include "crc.h"
+#include "repeated_char_result.h"
+#include "huff_codes.h"
+#include "encode_df.h"
+#include "igzip_level_buf_structs.h"
+#include "igzip_checksums.h"
+#include "igzip_wrapper.h"
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/endian.h>
+# define to_be32(x) bswap32(x)
+#elif defined (__APPLE__)
+#include <libkern/OSByteOrder.h>
+# define to_be32(x) OSSwapInt32(x)
+#elif defined (__GNUC__) && !defined (__MINGW32__)
+# include <byteswap.h>
+# define to_be32(x) bswap_32(x)
+#elif defined _WIN64
+# define to_be32(x) _byteswap_ulong(x)
+#endif
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void qpl_isal_deflate_body_huffman_only(struct isal_zstream *stream);
+    void qpl_isal_deflate_finish_huffman_only(struct isal_zstream *stream);
+    void qpl_isal_deflate_hash(struct isal_zstream *stream, uint8_t *dict, uint32_t dict_len);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+
+#endif

--- a/sources/isal/igzip/igzip_base.c
+++ b/sources/isal/igzip/igzip_base.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip_base.h"
+
 #include <stdint.h>
 #include "igzip_lib.h"
 #include "huffman.h"

--- a/sources/isal/igzip/igzip_base.h
+++ b/sources/isal/igzip/igzip_base.h
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPL_SOURCES_ISAL_IGZIP_IGZIP_BASE_C
+#define QPL_SOURCES_ISAL_IGZIP_IGZIP_BASE_C
+
+// includes extracted from sources/isal/igzip/igzip_base.c
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "huffman.h"
+#include "huff_codes.h"
+#include "bitbuf2.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void qpl_isal_deflate_body_base(struct isal_zstream *stream);
+    void qpl_isal_deflate_finish_base(struct isal_zstream *stream);
+    void qpl_isal_deflate_hash_base(uint16_t *hash_table, uint32_t hash_mask, uint32_t current_index, uint8_t *dict, uint32_t dict_len);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+
+#endif

--- a/sources/isal/igzip/igzip_icf_base.c
+++ b/sources/isal/igzip/igzip_icf_base.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip_icf_base.h"
+
 #include <stdint.h>
 #include "igzip_lib.h"
 #include "huffman.h"

--- a/sources/isal/igzip/igzip_icf_base.h
+++ b/sources/isal/igzip/igzip_icf_base.h
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPL_SOURCES_ISAL_IGZIP_IGZIP_ICF_BASE_C
+#define QPL_SOURCES_ISAL_IGZIP_IGZIP_ICF_BASE_C
+
+// includes extracted from sources/isal/igzip/igzip_icf_base.c
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "huffman.h"
+#include "huff_codes.h"
+#include "encode_df.h"
+#include "igzip_level_buf_structs.h"
+#include "unaligned.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void qpl_isal_deflate_icf_body_hash_hist_base(struct isal_zstream *stream);
+    void qpl_isal_deflate_icf_finish_hash_hist_base(struct isal_zstream *stream);
+    void qpl_isal_deflate_icf_finish_hash_map_base(struct isal_zstream *stream);
+    void qpl_isal_deflate_hash_mad_base(uint16_t *hash_table, uint32_t hash_mask, uint32_t current_index, uint8_t *dict, uint32_t dict_len);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+
+#endif

--- a/sources/isal/igzip/igzip_icf_body.c
+++ b/sources/isal/igzip/igzip_icf_body.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip_icf_body.h"
+
 #include "igzip_lib.h"
 #include "huffman.h"
 #include "encode_df.h"

--- a/sources/isal/igzip/igzip_icf_body.h
+++ b/sources/isal/igzip/igzip_icf_body.h
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPL_SOURCES_ISAL_IGZIP_IGZIP_ICF_BODY_C
+#define QPL_SOURCES_ISAL_IGZIP_IGZIP_ICF_BODY_C
+
+// includes extracted from sources/isal/igzip/igzip_icf_body.c
+#include "igzip_lib.h"
+#include "huffman.h"
+#include "encode_df.h"
+#include "igzip_level_buf_structs.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    void qpl_set_long_icf_fg_base(uint8_t *next_in, uint64_t processed, uint64_t input_size, struct deflate_icf *match_lookup);
+    uint64_t qpl_gen_icf_map_h1_base(struct isal_zstream *stream, struct deflate_icf *matches_icf_lookup, uint64_t input_size);
+    void qpl_icf_body_hash1_fillgreedy_lazy(struct isal_zstream *stream);
+    void qpl_icf_body_lazyhash1_fillgreedy_greedy(struct isal_zstream *stream);
+    void qpl_isal_deflate_icf_body(struct isal_zstream *stream);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+
+#endif

--- a/sources/isal/igzip/igzip_inflate.c
+++ b/sources/isal/igzip/igzip_inflate.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip_inflate.h"
+
 #include <stdint.h>
 #include "igzip_lib.h"
 #include "crc.h"

--- a/sources/isal/igzip/igzip_inflate.h
+++ b/sources/isal/igzip/igzip_inflate.h
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPL_SOURCES_ISAL_IGZIP_IGZIP_INFLATE_C
+#define QPL_SOURCES_ISAL_IGZIP_IGZIP_INFLATE_C
+
+// includes extracted from sources/isal/igzip/igzip_inflate.c
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "crc.h"
+#include "huff_codes.h"
+#include "igzip_checksums.h"
+#include "igzip_wrapper.h"
+#include "unaligned.h"
+#ifndef NO_STATIC_INFLATE_H
+#include "static_inflate.h"
+#endif
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/endian.h>
+# define bswap_32(x) bswap32(x)
+#elif defined (__APPLE__)
+#include <libkern/OSByteOrder.h>
+# define bswap_32(x) OSSwapInt32(x)
+#elif defined (__GNUC__) && !defined (__MINGW32__)
+# include <byteswap.h>
+#elif defined _WIN64
+# define bswap_32(x) _byteswap_ulong(x)
+#endif
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    int qpl_decode_huffman_code_block_stateless_base(struct inflate_state *state, uint8_t *start_out);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+
+#endif

--- a/sources/isal/igzip/igzip_wrapper.h
+++ b/sources/isal/igzip/igzip_wrapper.h
@@ -5,6 +5,8 @@
  ******************************************************************************/
 
 #ifndef IGZIP_WRAPPER_H
+#define IGZIP_WRAPPER_H
+
 
 #define DEFLATE_METHOD 8
 #define ZLIB_DICT_FLAG (1 << 5)

--- a/sources/isal/igzip/static_inflate.h
+++ b/sources/isal/igzip/static_inflate.h
@@ -1349,7 +1349,6 @@ struct inflate_huff_code_small static_dist_huff_code = {
         0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000	}
 };
 
-#endif
 struct inflate_huff_code_large pregen_lit_huff_code = {
     .short_code_lookup = {
         0x24000102, 0x88010265, 0x44000103, 0xa8010277,
@@ -2682,3 +2681,4 @@ struct inflate_huff_code_small pregen_dist_huff_code = {
         0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000	}
 };
 
+#endif


### PR DESCRIPTION
# Description

This PR is a superset of the previously opened PR https://github.com/intel/qpl/pull/38

The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by myself. The goal of this PR is to fix several buggy header files and improve compatibility with C++. The changes in this bugfix PR include:

- updates several header files to add include guards which were previously missing
- update two files to fix include guards which were incorrect.
- adds explicit declarations for implicitly extern functions in .c sources which did not previously have declarations in headers
- add header files as needed to support the new declarations

on-behalf-of: @permanence-ai [github-ai@permanence.ai](mailto:github-ai@permanence.ai)

# Checklist

- No new tests as this is purely a build-time correctness update
- Software path test results had only expected failures (per latest release notes) following the changes:

```
[----------] Global test environment tear-down
[==========] 385 tests from 125 test suites ran. (444798 ms total)
[  PASSED  ] 334 tests.
[  SKIPPED ] 45 tests, listed below:
. . .
[  FAILED  ] 6 tests, listed below:
[  FAILED  ] ta_c_api_deflate_stateful.dynamic_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.dynamic_high_verify
[  FAILED  ] ta_c_api_deflate_stateful.fixed_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.fixed_high_verify
[  FAILED  ] ta_c_api_deflate_stateful.static_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.static_high_verify

 6 FAILED TESTS
  YOU HAVE 22 DISABLED TESTS
```
