### PR TITLE
replace for loops with std algorithm usage (C++ modernization)

### DIFF
--- a/sources/middle-layer/compression/deflate/histogram.cpp
+++ b/sources/middle-layer/compression/deflate/histogram.cpp
@@ -16,6 +16,7 @@
 #include "deflate_hash_table.h"
 #include "dispatcher.hpp"
 #include "simple_memory_ops.hpp"
+#include <algorithm>
 
 namespace qpl::ml::compression {
 
@@ -27,33 +28,23 @@ void histogram_join_another(qpl_histogram &first_histogram_ptr,
     auto *first_ptr  = reinterpret_cast<uint32_t *>(&first_histogram_ptr);
     auto *second_ptr = reinterpret_cast<uint32_t *>(&second_histogram_ptr);
 
-    for (uint32_t i = 0; i < histogram_notes; i++) {
-        first_ptr[i] += second_ptr[i];
-    }
+    std::transform(first_ptr, first_ptr + histogram_notes, second_ptr, first_ptr, std::plus<>{});
 }
 
 static inline void isal_histogram_set_statistics(isal_histogram *isal_histogram_ptr,
                                                  const uint32_t *literal_length_histogram_ptr,
                                                  const uint32_t *offsets_histogram_ptr) {
-    for (uint32_t i = 0U; i < QPLC_DEFLATE_LL_TABLE_SIZE; i++) {
-        isal_histogram_ptr->lit_len_histogram[i] = literal_length_histogram_ptr[i];
-    }
+       std::copy_n(literal_length_histogram_ptr, QPLC_DEFLATE_LL_TABLE_SIZE, isal_histogram_ptr->lit_len_histogram);
 
-    for (uint32_t i = 0; i < QPLC_DEFLATE_D_TABLE_SIZE; i++) {
-        isal_histogram_ptr->dist_histogram[i] = offsets_histogram_ptr[i];
-    }
+    std::copy_n(offsets_histogram_ptr, QPLC_DEFLATE_D_TABLE_SIZE, isal_histogram_ptr->dist_histogram);
 }
 
 static inline void isal_histogram_get_statistics(const isal_histogram *isal_histogram_ptr,
                                                  uint32_t *literal_length_histogram_ptr,
                                                  uint32_t *offsets_histogram_ptr) {
-    for (uint32_t i = 0U; i < QPLC_DEFLATE_LL_TABLE_SIZE; i++) {
-        literal_length_histogram_ptr[i] = (uint32_t) isal_histogram_ptr->lit_len_histogram[i];
-    }
+    std::copy_n(isal_histogram_ptr->lit_len_histogram, QPLC_DEFLATE_LL_TABLE_SIZE, literal_length_histogram_ptr);
 
-    for (uint32_t i = 0U; i < QPLC_DEFLATE_D_TABLE_SIZE; i++) {
-        offsets_histogram_ptr[i] = (uint32_t) isal_histogram_ptr->dist_histogram[i];
-    }
+    std::copy_n(isal_histogram_ptr->dist_histogram, QPLC_DEFLATE_D_TABLE_SIZE, offsets_histogram_ptr);
 }
 
 static inline void remove_empty_places_in_histogram(qpl_histogram &histogram) {

--- a/sources/middle-layer/compression/deflate/streams/sw_compression_stream.cpp
+++ b/sources/middle-layer/compression/deflate/streams/sw_compression_stream.cpp
@@ -9,6 +9,7 @@
 #include "simple_memory_ops.hpp"
 #include "util/util.hpp"
 #include "deflate_hash_table.h"
+#include <algorithm>
 
 namespace qpl::ml::compression {
 void deflate_state<execution_path_t::software>::set_source(uint8_t *begin, uint32_t size) noexcept {
@@ -69,9 +70,7 @@ void deflate_state<execution_path_t::software>::reset_match_history() noexcept {
         if ((isal_stream_ptr_->total_in & 0xFFFF) == 0) {
             memset(hash_table, 0, hash_table_size);
         } else {
-            for (uint32_t i = 0; i < hash_table_size / 2; i++) {
-                hash_table[i] = static_cast<uint16_t>(isal_stream_ptr_->total_in);
-            }
+            std::fill_n(hash_table, hash_table_size / 2, static_cast<uint16_t>(isal_stream_ptr_->total_in));
         }
     }
 }

--- a/sources/middle-layer/compression/dictionary/dictionary_utils.cpp
+++ b/sources/middle-layer/compression/dictionary/dictionary_utils.cpp
@@ -11,6 +11,7 @@
 
 #include "dictionary_utils.hpp"
 #include "simple_memory_ops.hpp"
+#include <algorithm>
 
 namespace qpl::ml::compression {
 
@@ -104,14 +105,12 @@ static inline void init_hw_dict_hash_table(qpl_dictionary &dictionary) {
 
     if (ptrs_per_entry == 2U) {
         entries32 = (uint32_t*) (hw_hash_table_ptr);
-        for (uint32_t i = 0; i < 1024; i++) {
-            entry = hash_tbl[i];
-            entries32[i] =
-                ((entry >>  0) & 0x0000000F) |
-                ((entry >> 12) & 0x000000F0) |
-                ((entry <<  4) & 0x000FFF00) |
-                ((entry <<  0) & 0xFFF00000);
-        }
+        std::transform(std::begin(hash_tbl), std::end(hash_tbl), entries32, [&](uint32_t entry) {
+            return ((entry >>  0) & 0x0000000F) |
+                   ((entry >> 12) & 0x000000F0) |
+                   ((entry <<  4) & 0x000FFF00) |
+                   ((entry <<  0) & 0xFFF00000);
+        });
     } else {
         // ptrs_per_entry == 4
         entries64 = (uint64_t*) (hw_hash_table_ptr);

--- a/sources/middle-layer/compression/huffman_only/huffman_only_units.cpp
+++ b/sources/middle-layer/compression/huffman_only/huffman_only_units.cpp
@@ -13,6 +13,7 @@
 #include "bitbuf2.h"
 
 #include "compression/deflate/containers/huffman_table.hpp"
+#include <algorithm>
 
 namespace qpl::ml::compression {
 
@@ -195,9 +196,9 @@ auto convert_output_to_big_endian(huffman_only_state<execution_path_t::software>
                                                                 stream.isal_stream_ptr_->total_out);
 
     // Main cycle
-    for (uint32_t i = 0; i < actual_length; i++) {
-        array_ptr[i] = reverse_bits(array_ptr[i], 16);
-    }
+    std::transform(array_ptr, array_ptr + actual_length, array_ptr, [&](uint32_t val) {
+        return reverse_bits(val, 16);
+    });
 
     // Check if the last byte should be bit reversed (in case of odd stream length)
     if (stream.isal_stream_ptr_->total_out % 2 == 1) {


### PR DESCRIPTION
# Description

The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by myself. This code improvement PR updates several C++ files to replace conventional for loops with uses of std algorithms (transform, fill_n, and copy_n).

# Checklist
Test run summary

```
[----------] Global test environment tear-down
[==========] 388 tests from 125 test suites ran. (417845 ms total)
[  PASSED  ] 334 tests.
[  SKIPPED ] 48 tests, listed below:
. . .
[  FAILED  ] 6 tests, listed below:
[  FAILED  ] ta_c_api_deflate_stateful.dynamic_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.dynamic_high_verify
[  FAILED  ] ta_c_api_deflate_stateful.fixed_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.fixed_high_verify
[  FAILED  ] ta_c_api_deflate_stateful.static_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.static_high_verify

 6 FAILED TESTS
 YOU HAVE 22 DISABLED TESTS
```

on-behalf-of: @permanence-ai <github-ai@permanence.ai>