### PR TITLE
Enable Intel CET support in assembler sources

### DIFF
--- a/sources/isal/CMakeLists.txt
+++ b/sources/isal/CMakeLists.txt
@@ -103,3 +103,18 @@ if (NOT MSVC)
     # Setting POSIX compliance level for Linux builds (to use strnlen() function on Linux)
     target_compile_definitions(isal PRIVATE _POSIX_C_SOURCE=200809L)
 endif()
+
+# Enable Intel CET support in assembler sources
+check_c_source_compiles("
+    #if !defined(__CET__) || (__CET__ & 1) == 0
+    #error CET_BIT_0_NOT_SET
+    #endif
+    int main() { return 0; }
+" INTEL_CET_ENABLED)
+
+if(INTEL_CET_ENABLED)
+    target_compile_options(isal_asm PUBLIC "-DINTEL_CET_ENABLED")
+    message(STATUS "Intel CET protection is ENABLED")
+else()
+    message(STATUS "Intel CET protection is NOT enabled")
+endif()

--- a/sources/isal/include/reg_sizes.asm
+++ b/sources/isal/include/reg_sizes.asm
@@ -182,6 +182,21 @@
 
 %define XWORD(reg) reg %+ x
 
+%ifdef INTEL_CET_ENABLED
+  %ifdef __NASM_VER__
+    %ifidn __OUTPUT_FORMAT__,elf32
+section .note.gnu.property  note  alloc noexec align=4
+DD 0x00000004,0x0000000c,0x00000005,0x00554e47
+DD 0xc0000002,0x00000004,0x00000003
+    %endif
+    %ifidn __OUTPUT_FORMAT__,elf64
+section .note.gnu.property  note  alloc noexec align=8
+DD 0x00000004,0x00000010,0x00000005,0x00554e47
+DD 0xc0000002,0x00000004,0x00000003,0x00000000
+    %endif
+  %endif
+%endif
+
 %ifidn __OUTPUT_FORMAT__,elf32
 section .note.GNU-stack noalloc noexec nowrite progbits
 section .text


### PR DESCRIPTION
If Intel CET is enabled, add `.note.gnu.property` section with x86 assembly code which indicates IBT and SHSTK presence. This is required for ELF outputs to mark Intel CET support when Intel CET is enabled since all input files must be marked with Intel CET support in order for linker to mark output with Intel CET support.

The required ENDBR instructions were added by the upsteream ISA-L commit [cd888f01](https://github.com/intel/isa-l/commit/cd888f01) included in this copy of ISA-L code. The ISA-L upstream commit [57846f41](https://github.com/intel/isa-l/commit/57846f41) which added a section needed is missing here, so add it.

The object files with an assembly code and the resulting library have proper flags in the proper section as a result:

```
$ readelf -n sources/isal/igzip/encode_df.c.o sources/libqpl.so.1.9.0
File: sources/isal/igzip/encode_df.c.o
Displaying notes found in: .note.gnu.property
  Owner                Data size 	Description
  GNU                  0x00000010	NT_GNU_PROPERTY_TYPE_0
      Properties: x86 feature: IBT, SHSTK
File: sources/libqpl.so.1.9.0
Displaying notes found in: .note.gnu.property
  Owner                Data size 	Description
  GNU                  0x00000010	NT_GNU_PROPERTY_TYPE_0
      Properties: x86 feature: IBT, SHSTK
```